### PR TITLE
Support dots in renv keys

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -54,7 +54,7 @@ module.exports = grammar({
 			),
 
 		renv_key: $ =>
-			/[a-zA-Z_]+[a-zA-Z0-9_]*/,
+			/[a-zA-Z_]+[a-zA-Z0-9_.]*/,
 
 		renv_val: $ =>
 			/[^,>]+/,


### PR DESCRIPTION
For example, to control the size of plots with `knitr`:

```r
<<echo = FALSE, out.width = "50%">>=
knitr::include_graphics("foo/bar.png")
@
```